### PR TITLE
Fix Netlify deploy by changing function directory

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build]
-  functions = "./functions"
+  functions = "./lambda-build"


### PR DESCRIPTION
Not sure if it is set as ./functions for a reason, but changing it to ./lambda-deploy fixes the build.